### PR TITLE
Dereference refactoring

### DIFF
--- a/src/main/java/AddNullCheckBeforeDereferenceRefactoring.java
+++ b/src/main/java/AddNullCheckBeforeDereferenceRefactoring.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.eclipse.jdt.core.dom.AST;
 import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.Assignment;
 import org.eclipse.jdt.core.dom.ConditionalExpression;
 import org.eclipse.jdt.core.dom.Expression;
 import org.eclipse.jdt.core.dom.IfStatement;
@@ -62,6 +63,11 @@ public class AddNullCheckBeforeDereferenceRefactoring extends Refactoring {
 		if (node instanceof IfStatement ifStmt) {
 			return isApplicable(ifStmt);
 		}
+
+		if (node instanceof Assignment assignment) {
+			verifyRefactors(assignment);
+		}
+
 		System.out.println("[DEBUG] Node " + node.getClass().getSimpleName() + " is NOT applicable. Skipping.");
 		return false;
 	}
@@ -159,5 +165,19 @@ public class AddNullCheckBeforeDereferenceRefactoring extends Refactoring {
 			rewriter.replace(condition, pExpression, null);
 		}
 
+	}
+
+	/*
+	 * Checks Assignment node to see if it re-assigns an existing valid refactoring,
+	 * and if so removes it from validRefactors
+	 */
+	private void verifyRefactors(Assignment assignmentNode) {
+		Expression lhs = assignmentNode.getLeftHandSide();
+		if (!(lhs instanceof SimpleName varName)) {
+			return;
+		}
+		if (validRefactors.get(varName.toString()) != null) {
+			validRefactors.remove(varName.toString());
+		}
 	}
 }

--- a/src/main/java/AddNullCheckBeforeDereferenceRefactoring.java
+++ b/src/main/java/AddNullCheckBeforeDereferenceRefactoring.java
@@ -17,7 +17,28 @@ import org.eclipse.jdt.core.dom.SimpleName;
 import org.eclipse.jdt.core.dom.VariableDeclarationFragment;
 import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
 
-// (Assume Refactoring is an abstract base class provided in the same framework)
+/**
+ * A refactoring module that replaces checks on variables whose nullness is
+ * dependent on the nullness of another with another variable, by checking the
+ * original (independent) variable directly.*
+ * <p>
+ * Example:
+ * 
+ * <pre>{@code
+ * // Before:
+ * Class<?> dependentVar = (independentVar != null ? independentVar.getDependent() : null);
+ * if (dependentVar != null) {
+ * 	// ...
+ * }
+ *
+ * // After:
+ * Class<?> dependentVar = (independentVar != null ? independentVar.getDependent() : null);
+ * if (independentVar != null) {
+ * 	// ...
+ * }
+ * }</pre>
+ * <p>
+ */
 public class AddNullCheckBeforeDereferenceRefactoring extends Refactoring {
 	public static final String NAME = "AddNullCheckBeforeDereferenceRefactoring";
 
@@ -28,14 +49,18 @@ public class AddNullCheckBeforeDereferenceRefactoring extends Refactoring {
 	@SuppressWarnings("unused")
 	private List<Expression> possiblyNullExpressions;
 
-	/** Default constructor (for RefactoringEngine integration) */
+	/**
+	 * Default constructor (for RefactoringEngine integration)
+	 */
 	public AddNullCheckBeforeDereferenceRefactoring() {
-		super(); // Call to base class (if it expects a name/ID)
+		super();
 	}
 
-	/** Constructor that accepts a list of possibly-null expressions */
+	/**
+	 * Constructor that accepts a list of possibly-null expressions
+	 */
 	public AddNullCheckBeforeDereferenceRefactoring(List<Expression> possiblyNullExpressions) {
-		super();
+		super(); // Call to base class (if it expects a name/ID)
 		this.possiblyNullExpressions = possiblyNullExpressions;
 	}
 

--- a/src/main/java/AddNullCheckBeforeDereferenceRefactoring.java
+++ b/src/main/java/AddNullCheckBeforeDereferenceRefactoring.java
@@ -18,7 +18,7 @@ import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
 /**
  * A refactoring module that replaces checks on variables whose nullness is
  * dependent on the nullness of another with another variable, by checking the
- * original (independent) variable directly.*
+ * original (independent) variable directly.
  * <p>
  * Example:
  * 
@@ -31,7 +31,7 @@ import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
  *
  * // After:
  * Class<?> dependentVar = (independentVar != null ? independentVar.getDependent() : null);
- * if (independentVar != null) {
+ * if ((independentVar != null ? independentVar.getDependent() : null) != null) {
  * 	// ...
  * }
  * }</pre>

--- a/src/main/java/Refactoring.java
+++ b/src/main/java/Refactoring.java
@@ -1,7 +1,43 @@
+import java.util.ArrayList;
+import java.util.List;
+
 import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.Expression;
+import org.eclipse.jdt.core.dom.InfixExpression;
+import org.eclipse.jdt.core.dom.ParenthesizedExpression;
+import org.eclipse.jdt.core.dom.PrefixExpression;
 import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
 
 public abstract class Refactoring {
 	public abstract boolean isApplicable(ASTNode node);
+
 	public abstract void apply(ASTNode node, ASTRewrite rewriter);
+
+	/**
+	 * Recursively analyze an expression to get all the subexpressions that comprise
+	 * it. Finds inner expressions of PrefixExpressions, ParenthesizedExpressions,
+	 * and InfixExpressions
+	 * 
+	 * @param expr
+	 *            The expression to analyze
+	 * @return A list of all subexpressions within an expreesion
+	 */
+	public static List<Expression> getSubExpressions(Expression expr) {
+		List<Expression> exprList = new ArrayList<Expression>();
+
+		if (expr instanceof ParenthesizedExpression pExpr) {
+			exprList.addAll(getSubExpressions(pExpr.getExpression()));
+		} else if (expr instanceof PrefixExpression pExpr && pExpr.getOperator() == PrefixExpression.Operator.NOT) {
+			exprList.addAll(getSubExpressions(pExpr.getOperand()));
+		} else if (expr instanceof InfixExpression infix
+				&& (infix.getOperator().equals(InfixExpression.Operator.CONDITIONAL_AND)
+						|| infix.getOperator().equals(InfixExpression.Operator.CONDITIONAL_OR))) {
+			exprList.addAll(getSubExpressions(infix.getLeftOperand()));
+			exprList.addAll(getSubExpressions(infix.getRightOperand()));
+		} else {
+			exprList.add(expr);
+		}
+
+		return exprList;
+	}
 }

--- a/src/test/java/DereferenceTesting.java
+++ b/src/test/java/DereferenceTesting.java
@@ -10,8 +10,7 @@ import org.junit.jupiter.api.Test;
 public class DereferenceTesting {
 
 	public void test(String input, String expectedOutput) {
-		TestingEngine.testSingleRefactoring(input, expectedOutput,
-				AddNullCheckBeforeDereferenceRefactoring.NAME);
+		TestingEngine.testSingleRefactoring(input, expectedOutput, AddNullCheckBeforeDereferenceRefactoring.NAME);
 	}
 
 	@Test
@@ -145,7 +144,7 @@ public class DereferenceTesting {
 				public class Test {
 					private void test() {
 						Class<?> dependentObj = (independentObj != null ? independentObj.getDependent() : null);
-						Class<?> dependentObj = null;
+						dependentObj = null;
 						if (dependentObj != null) {
 							;
 						}
@@ -156,7 +155,7 @@ public class DereferenceTesting {
 				public class Test {
 					private void test() {
 						Class<?> dependentObj = (independentObj != null ? independentObj.getDependent() : null);
-						Class<?> dependentObj = null;
+						dependentObj = null;
 						if (dependentObj != null) {
 							;
 						}

--- a/src/test/java/DereferenceTesting.java
+++ b/src/test/java/DereferenceTesting.java
@@ -1,0 +1,168 @@
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Class to perform JUnit tests on the AddNullCheckBeforeDereferenceRefactoring
+ * refactoring module
+ * 
+ * @see DereferenceTesting
+ */
+public class DereferenceTesting {
+
+	public void test(String input, String expectedOutput) {
+		TestingEngine.testSingleRefactoring(input, expectedOutput,
+				AddNullCheckBeforeDereferenceRefactoring.NAME);
+	}
+
+	@Test
+	public void simpleTest() {
+		String input = """
+				public class Test {
+					private void test() {
+						Class<?> dependentObj = (independentObj != null ? independentObj.getDependent() : null);
+						if (dependentObj != null) {
+							;
+						}
+					}
+				}
+				""";
+		String expectedOutput = """
+				public class Test {
+					private void test() {
+						Class<?> dependentObj = (independentObj != null ? independentObj.getDependent() : null);
+						if ((independentObj != null ? independentObj.getDependent() : null)) {
+							;
+						}
+					}
+				}
+				""";
+		test(input, expectedOutput);
+	}
+
+	@Test
+	public void swappedSignsTest() {
+		String input = """
+				public class Test {
+					private void test() {
+						Class<?> dependentObj = (independentObj == null ? independentObj.getDependent() : null);
+						if (dependentObj != null) {
+							;
+						}
+					}
+				}
+				""";
+		String expectedOutput = """
+				public class Test {
+					private void test() {
+						Class<?> dependentObj = (independentObj == null ? independentObj.getDependent() : null);
+						if ((independentObj == null ? independentObj.getDependent() : null)) {
+							;
+						}
+					}
+				}
+				""";
+		test(input, expectedOutput);
+	}
+
+	@Test
+	public void prefixTest() {
+		String input = """
+				public class Test {
+					private void test() {
+						Class<?> dependentObj = (independentObj != null ? independentObj.getDependent() : null);
+						if (!(dependentObj != null)) {
+							;
+						}
+					}
+				}
+				""";
+		String expectedOutput = """
+				public class Test {
+					private void test() {
+						Class<?> dependentObj = (independentObj != null ? independentObj.getDependent() : null);
+						if (!((independentObj != null ? independentObj.getDependent() : null))) {
+							;
+						}
+					}
+				}
+				""";
+		test(input, expectedOutput);
+	}
+
+	@Test
+	public void infixTest() {
+		String input = """
+				public class Test {
+					private void test() {
+						Class<?> dependentObj = ((independentObj != null && 5 > 3) ? independentObj.getDependent() : null);
+						if (dependentObj != null) {
+							;
+						}
+					}
+				}
+				""";
+		String expectedOutput = """
+				public class Test {
+					private void test() {
+						Class<?> dependentObj = ((independentObj != null && 5 > 3) ? independentObj.getDependent() : null);
+						if (((independentObj != null && 5 > 3) ? independentObj.getDependent() : null)) {
+							;
+						}
+					}
+				}
+				""";
+		test(input, expectedOutput);
+	}
+
+	@Test
+	public void swappedSidesTest() {
+		String input = """
+				public class Test {
+					private void test() {
+						Class<?> dependentObj = (independentObj != null ? null : independentObj.getDependent());
+						if (dependentObj != null) {
+							;
+						}
+					}
+				}
+				""";
+		String expectedOutput = """
+				public class Test {
+					private void test() {
+						Class<?> dependentObj = (independentObj != null ? null : independentObj.getDependent());
+						if ((independentObj != null ? null : independentObj.getDependent())) {
+							;
+						}
+					}
+				}
+				""";
+		test(input, expectedOutput);
+	}
+
+	@Test
+	public void reassignmentTest() {
+		String input = """
+				public class Test {
+					private void test() {
+						Class<?> dependentObj = (independentObj != null ? independentObj.getDependent() : null);
+						Class<?> dependentObj = null;
+						if (dependentObj != null) {
+							;
+						}
+					}
+				}
+				""";
+		String expectedOutput = """
+				public class Test {
+					private void test() {
+						Class<?> dependentObj = (independentObj != null ? independentObj.getDependent() : null);
+						Class<?> dependentObj = null;
+						if (dependentObj != null) {
+							;
+						}
+					}
+				}
+				""";
+		test(input, expectedOutput);
+	}
+}


### PR DESCRIPTION
Updates the AddNullCheckBeforeRefactoring module to fix functionality and add testing. 

AddNullCheckBeforeRefactoring replaces checks on variables whose nullness depends on the nullness of another variable with a check on the original (independent) variable directly.

Example:
```
<p>
<pre>{@code
// Before:
Class<?> dependentVar = (independentVar != null ? independentVar.getDependent() : null);
if (dependentVar != null) {
	// ...
}
                                                                                         
// After:
Class<?> dependentVar = (independentVar != null ? independentVar.getDependent() : null);
if (independentVar != null) {
	// ...
}
}</pre>
<p>
```
